### PR TITLE
Disabled admin dashboard features

### DIFF
--- a/app/client/views/admin/users/users.html
+++ b/app/client/views/admin/users/users.html
@@ -226,6 +226,7 @@
             <td
               class="right aligned collapsing">
 
+              <!--
               <button
                 class="accept ui circular mini basic green icon button"
                 title="admit"
@@ -246,6 +247,7 @@
                 ng-click="waitlistUser($event, user, $index)">
                 <i class="wait icon"></i>
               </button>
+              -->
 
               <button
                 ng-click="toggleCheckIn($event, user, $index)"


### PR DESCRIPTION
Temporarily removed the action buttons on the admin dashboard to prevent admins from being able to admit, reject, or waitlist a user pre-maturely.